### PR TITLE
consoleManager.ts -> use `-m jupyter_console` instead of `-m jupyter console` to avoid using shims, improve portability

### DIFF
--- a/src/consoleManager.ts
+++ b/src/consoleManager.ts
@@ -209,7 +209,7 @@ export class ConsoleManager {
           const timeoutSeconds = getConsoleIsCompleteTimeout();
           const isCompleteTimeout = ` --ZMQTerminalInteractiveShell.kernel_is_complete_timeout=${timeoutSeconds}`;
 
-          const command = `"${pythonPath}" -m jupyter console${includeOtherOutput}${isCompleteTimeout} --existing "${connectionFile}"`;
+          const command = `"${pythonPath}" -m jupyter_console${includeOtherOutput}${isCompleteTimeout} --existing "${connectionFile}"`;
           this.consoleTerminal.sendText(command, true);
         }
       }, getConsoleTerminalStartDelay());


### PR DESCRIPTION
Per discussion on discord:
> I was observing some errors when using your vscode_jupyter_console extension when it ran `python -m jupyter console ...etc` to start the console it was failing with an error "failed to canonicalize script path". After a lot of digging I figured out that `python -m jupyter console` on windows at least is a shortcut to an included non-portable shim `jupyter-console.exe`. The solution is fortunately extremely simple and to simply call `python -m jupyter_console ...etc` (note the extra underscore). This bypasses the non-portable shim and directly uses the `__main__.py` entrypoint of the jupyter_console package.